### PR TITLE
Strategy callbacks to hook with custon deploy logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,14 @@ An alternative ERB script can be configured like this:
 or reading file directly:
 
     set(:aws_install_script) { File.read("deploy/templates/aws_install.sh.erb") }
+
+Callback triggers to add your own steps within deployments, eg. merge production configs:
+
+    task :prepare do
+        destination = fetch(:deploy_destination)
+        raise Capistrano::Error, "Deploy destination is not defined" if destination.nil? || destination.empty?
+
+        # do what ever you need 
+    end
+
+    on 'deploy:prepared', 'prepare'

--- a/lib/capistrano-s3copy-awscli/version.rb
+++ b/lib/capistrano-s3copy-awscli/version.rb
@@ -1,7 +1,7 @@
 module Capistrano
   module S3copy
     module Awscli
-      VERSION = "0.1.0"
+      VERSION = "0.2.0"
     end
   end
 end


### PR DESCRIPTION
This PR provides support for callback triggers, which allow to hook custom steps within `deploy!` atomic call, eg. merge production configs.
